### PR TITLE
Allow to easily change toolset from v120_xp to v143 (latest now)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,18 @@ fxctmp9_tmp/
 [Dd]ebug_dx9_mod_episodic/
 [Dd]arkinterval_shaders_dll/
 *.sentinel
+
+# Build artifacts
+*.dll
+*.dll.recipe
+*.exe.recipe
+*.exp
+*.idb
+*.lib
+
+# Resource scripts intermediate
+RC[a-z0-9]*
+*.res
+
+# MSVC static analyzer results
+*.lastcodeanalysissucceeded

--- a/src/darkinterval.sln
+++ b/src/darkinterval.sln
@@ -9,6 +9,14 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Server - Dark Interval", "g
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Shaders - Dark Interval", "materialsystem\stdshaders\game_shader_dx9_episodic.vcxproj", "{73F37A6E-6BFF-33FB-E47D-67E8212A7C6D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
+	ProjectSection(SolutionItems) = preProject
+		..\.gitignore = ..\.gitignore
+		..\LICENSE = ..\LICENSE
+		..\README.md = ..\README.md
+		..\thirdpartylegalnotices.txt = ..\thirdpartylegalnotices.txt
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86

--- a/src/game/client/c_baseentity.cpp
+++ b/src/game/client/c_baseentity.cpp
@@ -4755,7 +4755,11 @@ C_BaseEntity *C_BaseEntity::Instance( int iEnt )
 
 #ifdef WIN32
 #pragma warning( push )
+#if _MSC_VER < 1923
 #include <typeinfo.h>
+#else
+#include <typeinfo>
+#endif
 #pragma warning( pop )
 #endif
 

--- a/src/game/client/client_episodic.vcxproj
+++ b/src/game/client/client_episodic.vcxproj
@@ -111,7 +111,9 @@ if ERRORLEVEL 1 exit /b 1
     </PreLinkEvent>
     <Link>
       <AdditionalOptions> /ignore:4221</AdditionalOptions>
-      <AdditionalDependencies>;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'!='v120' And '$(PlatformToolset)'!='v120_xp'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib;legacy_stdio_definitions.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'=='v120'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'=='v120_xp'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)\client.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -207,7 +209,9 @@ if ERRORLEVEL 1 exit /b 1
     </PreLinkEvent>
     <Link>
       <AdditionalOptions> /ignore:4221</AdditionalOptions>
-      <AdditionalDependencies>;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'!='v120' And '$(PlatformToolset)'!='v120_xp'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib;legacy_stdio_definitions.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'=='v120'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'=='v120_xp'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)\client.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>

--- a/src/game/client/client_episodic.vcxproj
+++ b/src/game/client/client_episodic.vcxproj
@@ -1536,10 +1536,10 @@ exit 1
   <ItemGroup>
     <CustomBuild Include="..\..\public\tier0\pointeroverride.asm">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Compiling pointeroverride.asm</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(VCInstallDir)bin\ml.exe" /safeseh /c /Cp /Zi /Fo"$(IntDir)\%(Filename).obj" "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(VC_ExecutablePath_x86)\ml.exe" /safeseh /c /Cp /Zi /Fo"$(IntDir)\%(Filename).obj" "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).obj</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Compiling pointeroverride.asm</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(VCInstallDir)bin\ml.exe" /safeseh /c /Cp /Zi /Fo"$(IntDir)\%(Filename).obj" "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(VC_ExecutablePath_x86)\ml.exe" /safeseh /c /Cp /Zi /Fo"$(IntDir)\%(Filename).obj" "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)\%(Filename).obj</Outputs>
     </CustomBuild>
   </ItemGroup>

--- a/src/game/client/client_episodic.vcxproj
+++ b/src/game/client/client_episodic.vcxproj
@@ -1354,6 +1354,7 @@ exit 1
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\game\shared\vehicle_viewblend_shared.cpp" />
+    <ClCompile Include="ucrt_overrides.cpp" />
     <ClCompile Include="vgui_basepanel.cpp" />
     <ClCompile Include="vgui_bitmapbutton.cpp" />
     <ClCompile Include="vgui_bitmapimage.cpp" />

--- a/src/game/client/darkinterval/menu/ioptionspanel_controls.cpp
+++ b/src/game/client/darkinterval/menu/ioptionspanel_controls.cpp
@@ -138,7 +138,7 @@ void COptionsPanel_Controls::SaveControlsSettings()
 	}
 	else
 	{
-		m_pitch.SetValue(fabs(m_pitch.GetFloat()));
+		m_pitch.SetValue(fabsf(m_pitch.GetFloat()));
 	}
 
 	ConVarRef m_yaw("m_yaw");
@@ -149,7 +149,7 @@ void COptionsPanel_Controls::SaveControlsSettings()
 	}
 	else
 	{
-		m_yaw.SetValue(fabs(m_yaw.GetFloat()));
+		m_yaw.SetValue(fabsf(m_yaw.GetFloat()));
 	}
 
 	ApplyChangesToConVar("m_filter", m_pMouseSmoothingButton->IsSelected());

--- a/src/game/client/particlemgr.h
+++ b/src/game/client/particlemgr.h
@@ -119,7 +119,7 @@ entities. Each one is useful under different conditions.
 #include "tier0/fasttimer.h"
 #include "utllinkedlist.h"
 #include "utldict.h"
-#ifdef WIN32
+#if defined(WIN32) && _MSC_VER < 1923
 #include <typeinfo.h>
 #else
 #include <typeinfo>

--- a/src/game/client/physics_main_client.cpp
+++ b/src/game/client/physics_main_client.cpp
@@ -7,7 +7,11 @@
 #include "cbase.h"
 #include "c_baseentity.h"
 #ifdef WIN32
+#if _MSC_VER < 1923
 #include <typeinfo.h>
+#else
+#include <typeinfo>
+#endif
 #endif
 #include "tier0/vprof.h"
 

--- a/src/game/client/ucrt_overrides.cpp
+++ b/src/game/client/ucrt_overrides.cpp
@@ -1,0 +1,72 @@
+//========================================================================//
+//
+// Purpose: UCRT overrides
+//
+// $Workfile:     $
+// $Date:         $
+// $NoKeywords: $
+//===========================================================================//
+
+#include "cbase.h"
+
+#ifdef DARKINTERVAL
+
+#if _MSC_VER >= 1900
+
+#include <limits>
+
+// Can't include cmath directly as it has hypot already defined.
+_Check_return_ _CRT_JIT_INTRINSIC double __cdecl sqrt(_In_ double _X);
+
+// libucrt(d).lib defines _hypot as a part of C++11.
+// particles.lib(particle_sort.obj) does the same.
+//
+// What we do for modern compilers is to explicitly define _hypot here, as linker chooses impl from obj first.
+
+// Correct implementation is NOT naive one as have a lot of special requirements:
+// 
+// If no errors occur, the hypotenuse of a right - angled triangle, sqrt(x^2 + y^2), is returned.
+// If a range error due to overflow occurs, +HUGE_VAL, +HUGE_VALF, or +HUGE_VALL is returned.
+// If a range error due to underflow occurs, the correct result(after rounding) is returned.
+//
+// If the implementation supports IEEE floating - point arithmetic(IEC 60559),
+// std::hypot(x, y), std::hypot(y, x), and std::hypot(x, -y) are equivalent.
+// if one of the arguments is +-0, std::hypot(x, y) is equivalent to std::fabs called with the non-zero argument.
+// if one of the arguments is +-inf, std::hypot(x, y) returns +inf even if the other argument is NaN.
+// otherwise, if any of the arguments is NaN, NaN is returned.
+double _hypot(double x, double y)
+{
+	// Based on https://github.com/microsoft/STL/blob/082d80ae53925cad65e5f0b6a3ca00fd786fb96d/stl/src/special_math.cpp#L482
+	static_assert(std::numeric_limits<double>::is_iec559, "Double should be IEC559 aka IEEE 754.");
+
+	// std::hypot(x, y), std::hypot(y, x), and std::hypot(x, -y) are equivalent.
+	x = std::abs(x);
+	y = std::abs(y);
+
+	// if one of the arguments is +-inf, std::hypot(x, y) returns +inf even if the other argument is NaN.
+	static_assert(std::numeric_limits<double>::has_infinity, "Double should have infinity to work with.");
+	constexpr float inf = std::numeric_limits<double>::infinity();
+	if ( x == inf || y == inf )
+	{
+		return inf;
+	}
+
+	if (y > x)
+	{
+		std::swap(x, y);
+	}
+
+	constexpr float eps = std::numeric_limits<double>::epsilon();
+	if ( x * eps >= y )
+	{
+		return x;
+	}
+
+	const auto dydx = y / x;
+
+	return x * static_cast<double>( sqrt( 1 + dydx * dydx ) );
+}
+
+#endif
+
+#endif

--- a/src/game/server/physics_main.cpp
+++ b/src/game/server/physics_main.cpp
@@ -9,7 +9,11 @@
 
 #include "cbase.h"
 #ifdef _WIN32
-#include "typeinfo.h"
+#if _MSC_VER < 1923
+#include <typeinfo.h>
+#else
+#include <typeinfo>
+#endif
 // BUGBUG: typeinfo stomps some of the warning settings (in yvals.h)
 #pragma warning(disable:4244)
 #elif POSIX

--- a/src/game/server/server_episodic.vcxproj
+++ b/src/game/server/server_episodic.vcxproj
@@ -1561,10 +1561,10 @@ exit 1
   <ItemGroup>
     <CustomBuild Include="..\..\public\tier0\pointeroverride.asm">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Compiling pointeroverride.asm</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(VCInstallDir)bin\ml.exe" /safeseh /c /Cp /Zi /Fo"$(IntDir)\%(Filename).obj" "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(VC_ExecutablePath_x86)\ml.exe" /safeseh /c /Cp /Zi /Fo"$(IntDir)\%(Filename).obj" "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).obj</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Compiling pointeroverride.asm</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(VCInstallDir)bin\ml.exe" /safeseh /c /Cp /Zi /Fo"$(IntDir)\%(Filename).obj" "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(VC_ExecutablePath_x86)\ml.exe" /safeseh /c /Cp /Zi /Fo"$(IntDir)\%(Filename).obj" "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)\%(Filename).obj</Outputs>
     </CustomBuild>
   </ItemGroup>

--- a/src/game/server/server_episodic.vcxproj
+++ b/src/game/server/server_episodic.vcxproj
@@ -108,7 +108,9 @@ if ERRORLEVEL 1 exit /b 1
     </PreLinkEvent>
     <Link>
       <AdditionalOptions> /ignore:4221</AdditionalOptions>
-      <AdditionalDependencies>;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'!='v120' And '$(PlatformToolset)'!='v120_xp'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib;legacy_stdio_definitions.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'=='v120'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'=='v120_xp'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)\server.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -203,7 +205,9 @@ if ERRORLEVEL 1 exit /b 1
     </PreLinkEvent>
     <Link>
       <AdditionalOptions> /ignore:4221</AdditionalOptions>
-      <AdditionalDependencies>;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'!='v120' And '$(PlatformToolset)'!='v120_xp'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib;legacy_stdio_definitions.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'=='v120'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'=='v120_xp'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)\server.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>

--- a/src/materialsystem/stdshaders/game_shader_dx9_episodic.vcxproj
+++ b/src/materialsystem/stdshaders/game_shader_dx9_episodic.vcxproj
@@ -107,7 +107,9 @@ if ERRORLEVEL 1 exit /b 1
     </PreLinkEvent>
     <Link>
       <AdditionalOptions> /ignore:4221</AdditionalOptions>
-      <AdditionalDependencies>;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;version.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'!='v120' And '$(PlatformToolset)'!='v120_xp'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib;legacy_stdio_definitions.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'=='v120'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'=='v120_xp'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)\game_shader_dx9.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -198,7 +200,9 @@ exit 1
     </PreLinkEvent>
     <Link>
       <AdditionalOptions> /ignore:4221</AdditionalOptions>
-      <AdditionalDependencies>;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;version.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'!='v120' And '$(PlatformToolset)'!='v120_xp'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib;legacy_stdio_definitions.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'=='v120'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(PlatformToolset)'=='v120_xp'">;shell32.lib;user32.lib;advapi32.lib;gdi32.lib;comdlg32.lib;ole32.lib;winmm.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)\game_shader_dx9.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>

--- a/src/materialsystem/stdshaders/game_shader_dx9_episodic.vcxproj
+++ b/src/materialsystem/stdshaders/game_shader_dx9_episodic.vcxproj
@@ -341,10 +341,10 @@ exit 1
     </CustomBuild>
     <CustomBuild Include="..\..\public\tier0\pointeroverride.asm">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Compiling pointeroverride.asm</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(VCInstallDir)bin\ml.exe" /safeseh /c /Cp /Zi /Fo"$(IntDir)\%(Filename).obj" "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(VC_ExecutablePath_x86)\ml.exe" /safeseh /c /Cp /Zi /Fo"$(IntDir)\%(Filename).obj" "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).obj</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Compiling pointeroverride.asm</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(VCInstallDir)bin\ml.exe" /safeseh /c /Cp /Zi /Fo"$(IntDir)\%(Filename).obj" "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(VC_ExecutablePath_x86)\ml.exe" /safeseh /c /Cp /Zi /Fo"$(IntDir)\%(Filename).obj" "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)\%(Filename).obj</Outputs>
     </CustomBuild>
   </ItemGroup>

--- a/src/public/tier0/memalloc.h
+++ b/src/public/tier0/memalloc.h
@@ -382,7 +382,11 @@ public:
 
 	#pragma warning(disable:4290)
 	#pragma warning(push)
+	#if _MSC_VER < 1923
 	#include <typeinfo.h>
+	#else
+	#include <typeinfo>
+	#endif
 
 	// MEM_DEBUG_CLASSNAME is opt-in.
 	// Note: typeid().name() is not threadsafe, so if the project needs to access it in multiple threads

--- a/src/public/tier0/memoverride.cpp
+++ b/src/public/tier0/memoverride.cpp
@@ -486,6 +486,7 @@ void *__cdecl _nh_malloc_dbg( size_t nSize, int nFlag, int nBlockUse,
 	return g_pMemAlloc->Alloc(nSize, pFileName, nLine);
 }
 
+#if _MSC_VER < 1900 || defined(_DEBUG)
 void *__cdecl _malloc_dbg( size_t nSize, int nBlockUse,
 							const char *pFileName, int nLine )
 {
@@ -501,6 +502,7 @@ void *__cdecl _calloc_dbg( size_t nNum, size_t nSize, int nBlockUse,
 	memset(pMem, 0, nSize * nNum);
 	return pMem;
 }
+#endif
 
 void *__cdecl _calloc_dbg_impl( size_t nNum, size_t nSize, int nBlockUse, 
 	const char * szFileName, int nLine, int * errno_tmp )
@@ -508,6 +510,7 @@ void *__cdecl _calloc_dbg_impl( size_t nNum, size_t nSize, int nBlockUse,
 	return _calloc_dbg( nNum, nSize, nBlockUse, szFileName, nLine );
 }
 
+#if _MSC_VER < 1900 || defined(_DEBUG)
 void *__cdecl _realloc_dbg( void *pMem, size_t nNewSize, int nBlockUse,
 							const char *pFileName, int nLine )
 {
@@ -537,6 +540,7 @@ size_t __cdecl _msize_dbg( void *pMem, int nBlockUse )
 	return 0;
 #endif
 }
+#endif
 
 
 #ifdef _WIN32
@@ -635,7 +639,8 @@ ALLOC_CALL void * __cdecl _aligned_offset_recalloc( void * memblock, size_t coun
 
 extern "C"
 {
-	
+
+#if _MSC_VER < 1900 || defined(_DEBUG)
 int _CrtDumpMemoryLeaks(void)
 {
 	return 0;
@@ -650,6 +655,7 @@ int _CrtSetDbgFlag( int nNewFlag )
 {
 	return g_pMemAlloc->CrtSetDbgFlag( nNewFlag );
 }
+#endif
 
 #if _MSC_VER < 1900
 // 64-bit port.
@@ -674,6 +680,7 @@ void __cdecl _CrtSetDbgBlockType( void *pMem, int nBlockUse )
 	DebuggerBreak();
 }
 
+#if _MSC_VER < 1900 || defined(_DEBUG)
 _CRT_ALLOC_HOOK __cdecl _CrtSetAllocHook( _CRT_ALLOC_HOOK pfnNewHook )
 {
 	DebuggerBreak();
@@ -755,6 +762,7 @@ _CRT_REPORT_HOOK __cdecl _CrtSetReportHook( _CRT_REPORT_HOOK pfnNewHook )
 {
 	return (_CRT_REPORT_HOOK)g_pMemAlloc->CrtSetReportHook( pfnNewHook );
 }
+#endif
 
 int __cdecl _CrtDbgReport( int nRptType, const char * szFile,
         int nLine, const char * szModule, const char * szFormat, ... )
@@ -960,6 +968,7 @@ extern "C" int __cdecl _CrtGetCheckCount( void )
     return __crtDebugCheckCount;
 }
 
+#if _MSC_VER < 1900 || defined(_DEBUG)
 // aligned offset debug
 extern "C" void * __cdecl _aligned_offset_recalloc_dbg( void * memblock, size_t count, size_t size, size_t align, size_t offset, const char * f_name, int line_n )
 {
@@ -983,13 +992,16 @@ _CRT_REPORT_HOOK __cdecl _CrtGetReportHook( void )
 {
 	return NULL;
 }
+#endif
 
 #endif
+
+#if _MSC_VER < 1900 || defined(_DEBUG)
 int __cdecl _CrtReportBlockType(const void * pUserData)
 {
 	return 0;
 }
-
+#endif
 
 } // end extern "C"
 #endif // _WIN32
@@ -1051,11 +1063,13 @@ void __cdecl _free_dbg_nolock( void * pUserData, int nBlockUse)
         _free_dbg(pUserData, 0);
 }
 
+#if _MSC_VER < 1900 || defined(_DEBUG)
 _CRT_ALLOC_HOOK __cdecl _CrtGetAllocHook ( void)
 {
 		assert(0); 
         return NULL;
 }
+#endif
 
 static int __cdecl CheckBytes( unsigned char * pb, unsigned char bCheck, size_t nSize)
 {
@@ -1063,12 +1077,13 @@ static int __cdecl CheckBytes( unsigned char * pb, unsigned char bCheck, size_t 
         return bOkay;
 }
 
-
+#if _MSC_VER < 1900 || defined(_DEBUG)
 _CRT_DUMP_CLIENT __cdecl _CrtGetDumpClient ( void)
 {
 		assert(0); 
         return NULL;
 }
+#endif
 
 #if _MSC_VER >= 1400
 static void __cdecl _printMemBlockData( _locale_t plocinfo, _CrtMemBlockHeader * pHead)
@@ -1079,6 +1094,8 @@ static void __cdecl _CrtMemDumpAllObjectsSince_stat( const _CrtMemState * state,
 {
 }
 #endif
+
+#if _MSC_VER < 1900 || defined(_DEBUG)
 void * __cdecl _aligned_malloc_dbg( size_t size, size_t align, const char * f_name, int line_n)
 {
     return _aligned_malloc(size, align);
@@ -1106,6 +1123,7 @@ void __cdecl _aligned_free_dbg( void * memblock)
 {
     _aligned_free(memblock);
 }
+#endif
 
 #if _MSC_VER < 1900
 size_t __cdecl _CrtSetDebugFillThreshold( size_t _NewDebugFillThreshold)
@@ -1180,11 +1198,13 @@ _TSCHAR * __cdecl _ttempnam ( const _TSCHAR *dir, const _TSCHAR *pfx )
 }
 #endif
 
+#if _MSC_VER < 1900 || defined(_DEBUG)
 wchar_t * __cdecl _wcsdup_dbg ( const wchar_t * string, int nBlockUse, const char * szFileName, int nLine )
 {
 	Assert(0);
 	return 0;
 }
+#endif
 
 wchar_t * __cdecl _wcsdup ( const wchar_t * string )
 {


### PR DESCRIPTION
I have no `v120_xp` toolset, could you please check it still compiles well?

* Make solution compile on `v120_xp` and `v143` (just change in options) toolsets.
* Fix issue with `_hypot` which was added in C++11 and conflicts with `_hypot` defined in `particles.lib(particle_sort.obj)`.
* Move `.gitignore` upper in file system tree as need to ignore `bin\*.dll` from accidental commit.

Unfortunately, `v143` toolset works only in `Debug` mode as `Release` defines `_hypot` as intrinsic and disallow to override one.