### PR TITLE
Fix player be able to change weapon during firing.

### DIFF
--- a/src/game/shared/basecombatcharacter_shared.cpp
+++ b/src/game/shared/basecombatcharacter_shared.cpp
@@ -81,7 +81,7 @@ bool CBaseCombatCharacter::Weapon_CanSwitchTo( CBaseCombatWeapon *pWeapon )
 		if (pVehicle && !pPlayer->UsingStandardWeaponsInVehicle())
 			return false;
 #ifdef DARKINTERVAL
-		if (pPlayer->m_nButtons & IN_ATTACK | IN_ATTACK2 | IN_RELOAD)
+		if (pPlayer->m_nButtons & (IN_ATTACK | IN_ATTACK2 | IN_RELOAD))
 			return false; // never allow the player to switch weapons right while firing or reloading a weapon.
 #endif
 	}


### PR DESCRIPTION
`if (pPlayer->m_nButtons & IN_ATTACK | IN_ATTACK2 | IN_RELOAD)` is evaluated as
`if ((pPlayer->m_nButtons & IN_ATTACK) | IN_ATTACK2 | IN_RELOAD)`, not as 
`if (pPlayer->m_nButtons & (IN_ATTACK | IN_ATTACK2 | IN_RELOAD))`.

This MR fixes condition evaluation so player will not be able to changes weapon when he does primary / secondary attack or in reload,